### PR TITLE
chore: [RTD-1858] Update rtd trx to new evh

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -62,7 +62,7 @@ microservice-chart:
     idpay-common:
       TZ: TZ
     rtd-eventhub:
-      KAFKA_RTD_BROKER: kafka_broker_rtd
+      KAFKA_RTD_BROKER: kafka_broker_rtd_domain
       KAFKA_RTD_TOPIC: rtd_trx_topic
     idpay-eventhub-01:
       KAFKA_BROKER: kafka_broker
@@ -74,7 +74,7 @@ microservice-chart:
 
   envSecret:
     MONGODB_URI: mongodb-connection-string
-    KAFKA_RTD_SASL_JAAS_CONFIG: evh-rtd-trx-rtd-trx-consumer-jaas-config
+    KAFKA_RTD_SASL_JAAS_CONFIG: evh-rtd-trx-rtd-trx-consumer-rtd
     KAFKA_TRANSACTION_USER_ID_SPLITTER_SASL_JAAS_CONFIG: evh-idpay-transaction-user-id-splitter-idpay-transaction-user-id-splitter-producer-jaas-config-idpay-01
     KAFKA_TRANSACTION_SASL_JAAS_CONFIG: evh-idpay-transaction-idpay-transaction-producer-jaas-config-idpay-01
     KAFKA_ERRORS_SASL_JAAS_CONFIG: evh-idpay-errors-idpay-errors-producer-jaas-config-idpay-01


### PR DESCRIPTION
RTD is moving it rtd-trx queue to a domain eventhub namespace. This PR update references to new secret connection string and eventhub address